### PR TITLE
Crimre 56 only list submitted applications

### DIFF
--- a/app/controllers/api/v1/applications_controller.rb
+++ b/app/controllers/api/v1/applications_controller.rb
@@ -10,7 +10,7 @@ module Api
       # Omits any records that do not satisfy schema
       #
       def index
-        crime_apps = CrimeApplication.all.limit(LIMIT)
+        crime_apps = CrimeApplication.where.not(submitted_at: nil).limit(LIMIT)
 
         render json: ApplicationSerializer.collection(crime_apps).select(&:valid?)
       end

--- a/app/serializers/application_serializer.rb
+++ b/app/serializers/application_serializer.rb
@@ -38,8 +38,8 @@ class ApplicationSerializer
     Jbuilder.new do |json|
       json.id crime_app.id
       json.application_reference "LAA-#{crime_app.id[0..5]}"
-      json.application_start_date crime_app.updated_at.to_s
-      json.submission_date crime_app.updated_at.to_s
+      json.application_start_date crime_app.date_stamp.to_s
+      json.submission_date crime_app.submitted_at.to_s
       json.client_details client_details_to_builder
       json.case_details case_details_to_builder
       json.interests_of_justice(iojs_as_an_array, :reason, :type)

--- a/lib/laa_crime_apply_dev_api/types.rb
+++ b/lib/laa_crime_apply_dev_api/types.rb
@@ -45,7 +45,7 @@ module LaaCrimeApplyDevApi
   class Types
     include Dry.Types()
 
-    DateTime = Strict::DateTime | JSON::DateTime
+    DateTime = JSON::DateTime
     CorrespondenceAddressType = String.enum(*CORRESPONDENCE_ADDRESS_TYPES)
     OffenceClass = String.enum(*OFFENCE_CLASSES)
     CaseType = String.enum(*CASE_TYPES)

--- a/test/integration/navigation_test.rb
+++ b/test/integration/navigation_test.rb
@@ -20,13 +20,15 @@ class NavigationTest < ActionDispatch::IntegrationTest
       id: @uuid,
       updated_at: 1.day.ago,
       applicant: applicant,
-      case: OpenStruct.new(codefendants: [], charges: [])
+      case: OpenStruct.new(codefendants: [], charges: []),
+      date_stamp: 1.day.ago,
+      submitted_at: 1.second.ago
     )
   end
 
   test 'GET /api/applications' do
-    CrimeApplication.expects(:all).returns(
-      stub(limit: [@crime_application])
+    CrimeApplication.expects(:where).returns(
+      stub(not: stub(limit: [@crime_application]))
     )
 
     get '/api/applications'


### PR DESCRIPTION
Apply now sets submitted at. The dev api now only lists submitted applications and uses the submitted and date stamp date from Apply.